### PR TITLE
ajaxOData now returns jqXHR, plus new oDataAbort

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ It support server-side operations like:
 $('table#people').dataTable({
     "oDataUrl": "/odata/People",
   	"oDataViaJsonp": false,	// set to true for cross-domain requests
+    "oDataAbort": false, // set to true to cancel previous on-going request
     "ajax": ajaxOData,
     "serverSide": true, // set to true for OData server side filtering and sorting 
     "columns": [

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,6 @@ It support server-side operations like:
 $('table#people').dataTable({
     "oDataUrl": "/odata/People",
   	"oDataViaJsonp": false,	// set to true for cross-domain requests
-    "oDataAbort": false, // set to true to cancel previous on-going request
     "ajax": ajaxOData,
     "serverSide": true, // set to true for OData server side filtering and sorting 
     "columns": [

--- a/src/jquery.dataTables.odata-v4.js
+++ b/src/jquery.dataTables.odata-v4.js
@@ -177,7 +177,7 @@ function ajaxOData(data, callback, settings) {
 
 
 
-    $.ajax(jQuery.extend({}, settings.oInit.ajax, {
+    var jqXHR = $.ajax(jQuery.extend({}, settings.oInit.ajax, {
         "url": settings.oInit.oDataUrl,
         "data": request,
         "jsonp": oDataViaJsonp,
@@ -206,4 +206,6 @@ function ajaxOData(data, callback, settings) {
             callback(dataSource);
         }
     }));
+    
+    return jqXHR;
 };

--- a/src/jquery.dataTables.odata-v4.js
+++ b/src/jquery.dataTables.odata-v4.js
@@ -176,8 +176,14 @@ function ajaxOData(data, callback, settings) {
     }
 
 
+    if (settings.oInit.oAbort) {
+		    if (settings.jqXHR && settings.jqXHR.readystate != 4) {
+            settings.jqXHR.abort();
+        }
+	  }
 
-    var jqXHR = $.ajax(jQuery.extend({}, settings.oInit.ajax, {
+
+    $.ajax(jQuery.extend({}, settings.oInit.ajax, {
         "url": settings.oInit.oDataUrl,
         "data": request,
         "jsonp": oDataViaJsonp,
@@ -206,6 +212,4 @@ function ajaxOData(data, callback, settings) {
             callback(dataSource);
         }
     }));
-    
-    return jqXHR;
 };

--- a/src/jquery.dataTables.odata-v4.js
+++ b/src/jquery.dataTables.odata-v4.js
@@ -175,7 +175,11 @@ function ajaxOData(data, callback, settings) {
         }
     }
 
-
+    if (settings.oInit.oAbort) {
+        if (settings.jqXHR && settings.jqXHR.readystate != 4) {
+            settings.jqXHR.abort();
+        }
+    }
 
     var jqXHR = $.ajax(jQuery.extend({}, settings.oInit.ajax, {
         "url": settings.oInit.oDataUrl,

--- a/src/jquery.dataTables.odata-v4.js
+++ b/src/jquery.dataTables.odata-v4.js
@@ -176,14 +176,8 @@ function ajaxOData(data, callback, settings) {
     }
 
 
-    if (settings.oInit.oAbort) {
-		    if (settings.jqXHR && settings.jqXHR.readystate != 4) {
-            settings.jqXHR.abort();
-        }
-	  }
 
-
-    $.ajax(jQuery.extend({}, settings.oInit.ajax, {
+    var jqXHR = $.ajax(jQuery.extend({}, settings.oInit.ajax, {
         "url": settings.oInit.oDataUrl,
         "data": request,
         "jsonp": oDataViaJsonp,
@@ -212,4 +206,6 @@ function ajaxOData(data, callback, settings) {
             callback(dataSource);
         }
     }));
+    
+    return jqXHR;
 };


### PR DESCRIPTION
- Updated ajaxOData to now return  jqXHR - expected by DataTables.
- Additionally added oDataAbort - when set to true, it will cancel an ongoing previous request.
