### PR TITLE
Ajax errors don't trigger error.dt event - added error callback

### DIFF
--- a/src/jquery.dataTables.odata-v4.js
+++ b/src/jquery.dataTables.odata-v4.js
@@ -4,7 +4,7 @@ DATATABLES ODATA V4 ADDON
 --------------------------------------------------------------------------
 Enables jQuery DataTables to read data from an OData service
 
-Version: 1.0.2
+Version: 1.0.3
 Author: Michele Bersini
 Copyright 2016 Michele Bersini, all rights reserved.
 
@@ -208,6 +208,10 @@ function ajaxOData(data, callback, settings) {
             dataSource.recordsTotal = dataSource.recordsFiltered;
 
             callback(dataSource);
+        },
+        "error": function (jqXHR, textStatus, errorThrown) {
+        	settings.oApi._fnCallbackFire(settings, null, 'xhr', [settings, null, settings.jqXHR]);
+        	settings.oApi._fnProcessingDisplay(settings, false);
         }
     }));
     


### PR DESCRIPTION
Added error handler on ajax so that error.dt events get triggered. Withthout this any ajax errors are lost.

Please see: https://github.com/DataTables/DataTables/blob/260659560459d2fb86d2b4aee6ce4df55023aca2/media/js/jquery.dataTables.js#L2572-L2585 for reference
